### PR TITLE
Move base imports into their own file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,11 @@ Alternatively a Mixture simple project settings file is included which will comp
 
 You can also use your preferred methods for compiling sass as long as you have Sass 3.3.7+ and Sass-Globbing enabled.
 
+To just include the necessary partials from your existing sass project, you only need to import [base.scss](assets/sass/base.scss). No Sass-Globbing required.
+
 ### Sass file structure
 
-My preferred method is to work along the lines of the SMACSS & BEM method. In the sass folder there there are two folders — base and modules. The base folder has the Sassline base SCSS partials. The modules folder contains some demo SCSS partials with styles you can keep or remove. All new partials added to modules will be compiled into your css so work in here with new files.
+My preferred method is to work along the lines of the SMACSS & BEM method. In the sass folder there there are two folders — base and modules. The base folder has the Sassline base SCSS partials. The modules folder contains some demo SCSS partials with styles you can keep or remove. All new partials added to modules will be compiled into your css so work in here with new files. 
 
 ### More on information on using Sassline
 

--- a/assets/sass/base.scss
+++ b/assets/sass/base.scss
@@ -1,0 +1,7 @@
+// Import Sassline base SCSS files in order so variables are read correctly.
+@import "base/reset";
+@import "base/variables";
+@import "base/modular-scale";
+@import "base/mixins";
+@import "base/typography";
+@import "base/layouts";

--- a/assets/sass/style.scss
+++ b/assets/sass/style.scss
@@ -1,13 +1,8 @@
 /* CSS compiled from SCSS */
 /* --------------------------------------- */
 
-// Import Sassline base SCSS files in order so variables are read correctly.
-@import "base/reset";
-@import "base/variables";
-@import "base/modular-scale";
-@import "base/mixins";
-@import "base/typography";
-@import "base/layouts";
+// Import Sassline base.
+@import "base";
 
 // Import all SCSS modules with Sass globbing.
 @import "modules/*.*";


### PR DESCRIPTION
This is a cool project. :+1: 

I needed to use it as a library but that wasn't easy. Webpack's sass-loader did not get along with node-sass-globbing. And I didn't even need all that. I think others may find it more helpful to easily access the core files directly rather than through everything else. 