### PR TITLE
Update bower.json to include `main` and `ignore`

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,5 +12,11 @@
     "boilerplate",
     "modular-scale"
   ],
+  "main": "assets/sass/style.scss",
+  "ignore": [
+    "**/.*",
+    "*.json",
+    "Gemfile"
+    ]
   "license": "MIT"
 }


### PR DESCRIPTION
Per guidance @ https://github.com/bower/spec/blob/master/json.md
…Helps when including sassline as a bower dependency through task runners that may be looking for the entry-point file.